### PR TITLE
Revise Dependabot schedule and labels for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,9 +26,7 @@ updates:
   open-pull-requests-limit: 10
   package-ecosystem: npm
   schedule:
-    day: monday
-    interval: weekly
-    time: "06:00"
+    interval: daily
   cooldown:
     default-days: 1
     exclude: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,27 +33,22 @@ updates:
     default-days: 1
     exclude: ["*"]
 
-- commit-message:
-    include: scope
-    prefix: build(deps)
-  directory: /
-  groups:
-    github-actions:
-      patterns:
-      - "*"
-      update-types:
-      - minor
-      - patch
-  ignore:
-  - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
-  labels:
-  - dependencies
-  - github_actions
-  package-ecosystem: github-actions
-  schedule:
-    day: monday
-    interval: weekly
-    time: "07:00"
-  cooldown:
-    default-days: 1
-    exclude: ["*"]
+  - package-ecosystem: github-actions
+    directory: /
+    ignore:
+    - dependency-name: "github/gh-aw-actions/**" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 1
+      exclude: ["*"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
Updated Dependabot configuration for GitHub Actions to run daily and adjusted labels.